### PR TITLE
Fixed deprecated warning in Django 1.5

### DIFF
--- a/ios_notifications/admin.py
+++ b/ios_notifications/admin.py
@@ -1,7 +1,11 @@
 # -*- coding: utf-8 -*-
 
+try:
+    from django.conf.urls import patterns, url
+except ImportError:  # deprecated since Django 1.4
+    from django.conf.urls.defaults import patterns, url
+
 from django.contrib import admin
-from django.conf.urls.defaults import patterns, url
 from django.template.response import TemplateResponse
 from django.shortcuts import get_object_or_404
 

--- a/ios_notifications/urls.py
+++ b/ios_notifications/urls.py
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
 
-from django.conf.urls.defaults import url, patterns
+try:
+    from django.conf.urls import patterns, url
+except ImportError:  # deprecated since Django 1.4
+    from django.conf.urls.defaults import patterns, url
+
 from .api import routes
 
 urlpatterns = patterns('',


### PR DESCRIPTION
Use `django.conf.urls` instead of deprecated `django.conf.urls.defaults` (backward compatible)
