### PR TITLE
Use local urls.py for test to prevent reverse from failing

### DIFF
--- a/ios_notifications/tests.py
+++ b/ios_notifications/tests.py
@@ -96,6 +96,8 @@ class APNServiceTest(TestCase):
 
 
 class APITest(TestCase):
+    urls = 'ios_notifications.urls'
+
     def setUp(self):
         self.service = APNService.objects.create(name='sandbox', hostname='gateway.sandbox.push.apple.com')
         self.device_token = TOKEN
@@ -165,6 +167,8 @@ class APITest(TestCase):
 
 
 class AuthenticationDecoratorTestAuthBasic(TestCase):
+    urls = 'ios_notifications.urls'
+
     def setUp(self):
         self.service = APNService.objects.create(name='sandbox', hostname='gateway.sandbox.push.apple.com')
         self.device_token = TOKEN


### PR DESCRIPTION
It is possible that users would not include ios_notifications.urls to global urlconf.
(For example one might use django-tastypie for API)
In this case tests would fail because reverse would be unable to find correct urls.
I suggest using local urls for tests that need reverse.
