### PR TITLE
Set a default block_type for EncryptedCharField.

### DIFF
--- a/ios_notifications/models.py
+++ b/ios_notifications/models.py
@@ -96,7 +96,9 @@ class APNService(BaseService):
     """
     certificate = models.TextField()
     private_key = models.TextField()
-    passphrase = EncryptedCharField(null=True, blank=True, help_text='Passphrase for the private key')
+    passphrase = EncryptedCharField(
+        null=True, blank=True, help_text='Passphrase for the private key',
+        block_type='MODE_CBC')
 
     PORT = 2195
     fmt = '!cH32sH%ds'


### PR DESCRIPTION
This is required by django-field 0.2+ which raise a warning when the
block_type is not set.
