### PR TITLE
Should specify chunk_size when calling _write_message function

### DIFF
--- a/ios_notifications/models.py
+++ b/ios_notifications/models.py
@@ -138,7 +138,7 @@ class APNService(BaseService):
                     # if the device no longer accepts push notifications from your app
                     # and you send one to it anyways, Apple immediately drops the connection to your APNS socket.
                     # http://stackoverflow.com/a/13332486/1025116
-                    self._write_message(notification, chunk[i + 1:])
+                    self._write_message(notification, chunk[i + 1:], chunk_size)
 
             self._disconnect()
 


### PR DESCRIPTION
When starting again from the next device after connection been reset, the program should specify the correct `chunk_size` otherwise the whole process will be failed.
