### PR TITLE
Saving utf-8 texts in json.dumps as UTF8, not as \u escape sequence

### DIFF
--- a/ios_notifications/models.py
+++ b/ios_notifications/models.py
@@ -241,7 +241,7 @@ class Notification(models.Model):
         extra = self.extra
         if extra is not None:
             message.update(extra)
-        payload = json.dumps(message, separators=(',', ':'))
+        payload = json.dumps(message, separators=(',', ':'), ensure_ascii=False).encode('utf8')
         return payload
 
 


### PR DESCRIPTION
when you are using non ascii character like 

json_stringv = json.dumps("ברי צקלה")
print json_string
"\u05d1\u05e8\u05d9 \u05e6\u05e7\u05dc\u05d4"

this is definitely will exceed 256 byte

but if we used manually encoding

json_string = json.dumps(u"ברי צקלה", ensure_ascii=False).encode('utf8')

> > > json_string
> > > '"\xd7\x91\xd7\xa8\xd7\x99 \xd7\xa6\xd7\xa7\xd7\x9c\xd7\x94"'
> > > print json_string
> > > "ברי צקלה"

as apple accepting utf8 json, its worked with me perfectly  
