### PR TITLE
Avoid multiple notification for users

### DIFF
--- a/ios_notifications/models.py
+++ b/ios_notifications/models.py
@@ -139,6 +139,7 @@ class APNService(BaseService):
                     # and you send one to it anyways, Apple immediately drops the connection to your APNS socket.
                     # http://stackoverflow.com/a/13332486/1025116
                     self._write_message(notification, chunk[i + 1:], chunk_size)
+                    return
 
             self._disconnect()
 


### PR DESCRIPTION
Hi,

Why doesn't the exception handler stop the loop?

What if it raises a problem on the 10th user and recursively call _write_message while still looping from the 11th?
