### PR TITLE
support slient notification

### DIFF
--- a/ios_notifications/models.py
+++ b/ios_notifications/models.py
@@ -183,7 +183,7 @@ class Notification(models.Model):
     service = models.ForeignKey(APNService)
     message = models.CharField(max_length=200, blank=True, help_text='Alert message to display to the user. Leave empty if no alert should be displayed to the user.')
     badge = models.PositiveIntegerField(null=True, blank=True, help_text='New application icon badge number. Set to None if the badge number must not be changed.')
-    slient = models.BooleanField(null=True, blank=True, help_text='set True to send a slient notification')
+    silent = models.BooleanField(null=True, blank=True, help_text='set True to send a silent notification')
     sound = models.CharField(max_length=30, blank=True, help_text='Name of the sound to play. Leave empty if no sound should be played.')
     created_at = models.DateTimeField(auto_now_add=True)
     last_sent_at = models.DateTimeField(null=True, blank=True)
@@ -266,7 +266,7 @@ class Notification(models.Model):
             aps['badge'] = self.badge
         if self.sound:
             aps['sound'] = self.sound
-        if self.slient:
+        if self.silent:
             aps['content-available'] = 1
         message = {'aps': aps}
         extra = self.extra


### PR DESCRIPTION
Add a field named slient to  Notification, if silent is True set aps['content-available'] = 1

Because of the file ios_notifications/migrations/0003_auto__add_field_notification_loc_payload.py  use users.user , I use django.contrib.autu.models.User.  I doesn't commit my schema migration file.
