### PR TITLE
Fix ModelForm deprecation warnings when using Django>=1.7

### DIFF
--- a/ios_notifications/forms.py
+++ b/ios_notifications/forms.py
@@ -10,11 +10,13 @@ from .models import Device, APNService
 class DeviceForm(forms.ModelForm):
     class Meta:
         model = Device
+        exclude = []
 
 
 class APNServiceForm(forms.ModelForm):
     class Meta:
         model = APNService
+        exclude = []
 
     START_CERT = '-----BEGIN CERTIFICATE-----'
     END_CERT = '-----END CERTIFICATE-----'


### PR DESCRIPTION
The correct way would be to use:
```python
fields = '__all__'
```

Unfortunately, it was introduced in Django==1.6, and this library still supports the old versions of Django and therefore fix has to look like this:
```python
exclude = []
```