### PR TITLE
Adapts forms to Django 1.8

### DIFF
--- a/ios_notifications/forms.py
+++ b/ios_notifications/forms.py
@@ -10,13 +10,13 @@ from .models import Device, APNService
 class DeviceForm(forms.ModelForm):
     class Meta:
         model = Device
-        exclude = []
+        fields = '__all__'
 
 
 class APNServiceForm(forms.ModelForm):
     class Meta:
         model = APNService
-        exclude = []
+        fields = '__all__'
 
     START_CERT = '-----BEGIN CERTIFICATE-----'
     END_CERT = '-----END CERTIFICATE-----'


### PR DESCRIPTION
Proposed solution fixes forms for Django 1.8 (current LTS) but only works with Django >= 1.6. End of support for Django 1.5 and older already happened time ago.

For more information please see: https://docs.djangoproject.com/en/1.8/topics/forms/modelforms/#selecting-the-fields-to-use