### PR TITLE
replace old option_list with parser.add_argument

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,9 @@ python:
   - "2.7"
 script: ./runtests.sh
 env:
-  - DJANGO_VERSION=1.6.8
-  - DJANGO_VERSION=1.7.8
   - DJANGO_VERSION=1.8.2
   - DJANGO_VERSION=1.9.4
+  - DJANGO_VERSION=1.10.3
 
 install:
   - pip install -q Django==$DJANGO_VERSION

--- a/ios_notifications/api.py
+++ b/ios_notifications/api.py
@@ -6,7 +6,7 @@ from django.http import HttpResponseNotAllowed, QueryDict
 from django.views.decorators.csrf import csrf_exempt
 from django.shortcuts import get_object_or_404
 from django.db import IntegrityError
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 from django.utils.decorators import method_decorator
 
 from .models import Device
@@ -101,7 +101,7 @@ class DeviceResource(BaseResource):
             try:
                 user_ids = request.PUT.getlist('users')
                 device.users.remove(*[u.id for u in device.users.all()])
-                device.users.add(*User.objects.filter(id__in=user_ids))
+                device.users.add(*get_user_model().objects.filter(id__in=user_ids))
             except (ValueError, IntegrityError) as e:
                 return JSONResponse({'error': e.message}, status=400)
             del request.PUT['users']

--- a/ios_notifications/management/commands/push_ios_notification.py
+++ b/ios_notifications/management/commands/push_ios_notification.py
@@ -11,41 +11,53 @@ from ios_notifications.models import Notification, APNService
 
 class Command(BaseCommand):
     help = 'Create and immediately send a push notification to iOS devices'
-    option_list = BaseCommand.option_list + (
-        make_option('--message',
-                    help='The main message to be sent in the notification',
-                    dest='message',
-                    default=''),
-        make_option('--badge',
-                    help='The badge number of the notification',
-                    dest='badge',
-                    default=None),
-        make_option('--sound',
-                    help='The sound for the notification',
-                    dest='sound',
-                    default=''),
-        make_option('--service',
-                    help='The id of the APN Service to send this notification through',
-                    dest='service',
-                    default=None),
-        make_option('--extra',
-                    help='Custom notification payload values as a JSON dictionary',
-                    dest='extra',
-                    default=None),
-        make_option('--persist',
+    def add_arguments(self, parser):
+        parser.add_argument('--message',
+            help='The main message to be sent in the notification',
+            action='store',
+            dest='message',
+            default='')
+        
+        parser.add_argument('--badge',
+            help='The badge number of the notification',
+            action='store',
+            dest='badge',
+            default=None)
+        
+        parser.add_argument('--sound',
+            help='The sound for the notification',
+            action='store',
+            dest='sound',
+            default='')
+        
+        parser.add_argument('--service',
+            help='The id of the APN Service to send this notification through',
+            action='store',
+            dest='service',
+            default=None)
+        
+        parser.add_argument('--extra',
+            help='Custom notification payload values as a JSON dictionary',
+            action='store',
+            dest='extra',
+            default=None)
+        
+        parser.add_argument('--persist',
                     help='Save the notification in the database after pushing it.',
                     action='store_true',
                     dest='persist',
-                    default=None),
-        make_option('--no-persist',
+                    default=None)
+        
+        parser.add_argument('--no-persist',
                     help='Prevent saving the notification in the database after pushing it.',
                     action='store_false',
-                    dest='persist'),  # Note: same dest as --persist; they are mutually exclusive
-        make_option('--batch-size',
+                    dest='persist')  # Note: same dest as --persist; they are mutually exclusive
+        
+        parser.add_argument('--batch-size',
                     help='Notifications are sent to devices in batches via the APN Service. This controls the batch size. Default is 100.',
+                    action='store',
                     dest='chunk_size',
-                    default=100),
-    )
+                    default=100)
 
     def handle(self, *args, **options):
         if options['service'] is None:


### PR DESCRIPTION
This brings the `./manage.py push_ios_notification` command up to date with django 1.8+